### PR TITLE
Patch to indicate monster is carrying item in sidebar.

### DIFF
--- a/brogue/src/brogue/IO.c
+++ b/brogue/src/brogue/IO.c
@@ -4151,6 +4151,14 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
 			applyColorAugment(&monstBackColor, &black, 100);
 		}
 		plotCharWithColor(monstChar, 0, y, &monstForeColor, &monstBackColor);
+		
+		//patch to indicate monster is carrying item
+		if(monst->carriedItem) {
+			plotCharWithColor(monst->carriedItem->displayChar, 1, y, &itemColor, &black);
+		}
+		//end patch
+		
+		
 		monsterName(monstName, monst, false);
 		upperCase(monstName);
         
@@ -4176,8 +4184,12 @@ short printMonsterInfo(creature *monst, short y, boolean dim, boolean highlight)
         
         sprintf(buf, ": %s", monstName);
         
-		printString("                   ", 1, y, &white, &black, 0);
-		printString(buf, 1, y++, (dim ? &gray : &white), &black, 0);
+		//patch to indicate monster is carrying item
+		//printString("                   ", 1, y, &white, &black, 0);
+		//printString(buf, 1, y++, (dim ? &gray : &white), &black, 0);
+		printString("                   ", monst->carriedItem?2:1, y, &white, &black, 0);
+		printString(buf, monst->carriedItem?2:1, y++, (dim ? &gray : &white), &black, 0);
+		//end patch
 	}
     
     // mutation, if any


### PR DESCRIPTION
Because web-brogue doesn't feature mouseover, it is a little irritating to switch to keyboard cursor control to check if a monster is carrying an item.

This patch shows the symbol of the item that the monster is carrying next to its own symbol in the sidebar. Very useful when being robbed by a pack of monkeys!

![item_icon_sidebar](https://cloud.githubusercontent.com/assets/5215740/13834890/e65f8444-ebaf-11e5-96f3-de54f776e82f.png)
