### PR TITLE
Speed up DOM rendering

### DIFF
--- a/client/style.css
+++ b/client/style.css
@@ -320,7 +320,7 @@ button {
 .console-cell {
     font-family: BrogueCE;
     position : absolute;
-    overflow: hidden;
+    overflow: visible;
     text-align: left;
     cursor: default;
 }

--- a/client/views/console-cell-view.js
+++ b/client/views/console-cell-view.js
@@ -41,7 +41,7 @@ define([
                     this.model.get("backgroundGreen") + "," +
                     this.model.get("backgroundBlue") + ")";
 
-            this.el.innerHTML = cellCharacter;
+            this.el.textContent = cellCharacter;
             this.el.style.color = rgbForegroundString;
             this.el.style.backgroundColor = rgbBackgroundString;
             return this;


### PR DESCRIPTION
Two small tweaks to make DOM layout computation about 15 times faster on Chrome. (This is in a VM with no GPU acceleration.)

Before patch: 2 typical frames are rendered in 611 ms. DOM layout wastes ~200 ms per frame.

![before](https://user-images.githubusercontent.com/69065091/107865712-bcc87b00-6e26-11eb-8b81-f87dbd727909.png)

After patch: 2 typical frames are rendered in 46 ms. DOM layout takes just 3 ms per frame.

![after](https://user-images.githubusercontent.com/69065091/107865716-c2be5c00-6e26-11eb-9f8b-27ab2b24992e.png)

There is also a gain on Firefox, but not as dramatic: DOM drops from 42% of CPU time to ~35% of CPU time. Firefox feels smoother than Chrome both before and after.